### PR TITLE
add basic ruff commands to alphabuild core

### DIFF
--- a/build-support/alpha-build/config/python.mk
+++ b/build-support/alpha-build/config/python.mk
@@ -8,6 +8,7 @@ ISORT_CONFIG=build-support/python/tools-config/pyproject.toml
 BLACK_CONFIG=build-support/python/tools-config/pyproject.toml
 BANDIT_CONFIG=build-support/python/tools-config/.bandit.yml
 PYTEST_CONFIG=build-support/python/tools-config/pyproject.toml
+RUFF_CONFIG=build-support/python/tools-config/pyproject.toml
 
 # Tools config
 #DEFAULT_PYTEST_MARKS=""
@@ -26,3 +27,4 @@ PYLINT_FLAGS=--rcfile=$(PYLINT_CONFIG)
 PYTEST_FLAGS=-c $(PYTEST_CONFIG)
 MYPY_FLAGS=--config-file $(MYPY_CONFIG)
 PIPREQS_FLAGS=--print
+RUFF_FLAGS=--config $(RUFF_CONFIG)

--- a/build-support/alpha-build/core/python/format.mk
+++ b/build-support/alpha-build/core/python/format.mk
@@ -40,3 +40,15 @@ pyupgrade:
 	$(eval targets := $(onpy))
 	if $(call lang,$(targets),$(REGEX_PY)); then  \
 	find $(targets) -type f -regex $(REGEX_PY) -print0 | $(gnu_xargs) -0 $(python) -m pyupgrade $(PYUPGRADE_FLAGS) ; fi
+
+.PHONY: ruff-format
+ruff-format:
+	$(eval targets := $(onpy))
+	if $(call lang,$(targets),$(REGEX_PY)); then  \
+	$(python) -m ruff format $(RUFF_FLAGS) $(targets); fi
+
+.PHONY: ruff-lint-fix
+ruff-lint-fix:
+	$(eval targets := $(onpy))
+	if $(call lang,$(targets),$(REGEX_PY)); then  \
+	$(python) -m ruff check --fix $(RUFF_FLAGS) $(targets); fi

--- a/build-support/alpha-build/core/python/lint.mk
+++ b/build-support/alpha-build/core/python/lint.mk
@@ -67,3 +67,15 @@ pydocstyle:
 	$(eval targets := $(onpy))
 	if $(call lang,$(targets),$(REGEX_PY)); then  \
   	$(python) -m pydocstyle $(PYDOCSTYLE_FLAGS) $(targets); fi
+
+.PHONY: ruff-format-check
+ruff-format-check:
+	$(eval targets := $(onpy))
+	if $(call lang,$(targets),$(REGEX_PY)); then  \
+	$(python) -m ruff format --check --diff $(RUFF_FLAGS) $(targets); fi
+
+.PHONY: ruff-lint-check
+ruff-lint-check:
+	$(eval targets := $(onpy))
+	if $(call lang,$(targets),$(REGEX_PY)); then  \
+	$(python) -m ruff check $(RUFF_FLAGS) $(targets); fi


### PR DESCRIPTION
# Pull Request Template

## Description

Adding commands to alpha build for ruff  - that is to format, lint, format check and fix lint suggestions - using pyproject.toml for ruff config. Individual projects will set their own config.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Ran make ruff-format-check, ruff-lint-check, ruff-format and ruff-lint-fix on some sample projects

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
